### PR TITLE
BLUECHECK-13: Set up configuration options in BlueJ's preferences

### DIFF
--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
@@ -19,6 +19,11 @@ import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import no.ntnu.iir.bluej.checkstyle.checker.CheckerService;
 
+/**
+ * Represents a Preferences class.
+ * Responsible for loading and saving preferences utilizing BlueJ internals.
+ * Also responsible for generating the configuration options in the Preferences tab in BlueJ.
+ */
 public class CheckstylePreferences implements PreferenceGenerator {
   private BlueJ blueJ;
   private GridPane pane;
@@ -88,6 +93,11 @@ public class CheckstylePreferences implements PreferenceGenerator {
 
   }
 
+  /**
+   * Returns the Window that should be rendered to the BlueJ preferences.
+   * 
+   * @return the Window that should be rendered to the BlueJ preferences
+   */
   @Override
   public Pane getWindow() {
     return this.pane;
@@ -131,6 +141,9 @@ public class CheckstylePreferences implements PreferenceGenerator {
     );
   }
 
+  /**
+   * Configures the CheckerService to use the user defined preferences.
+   */
   private void configureCheckerService() {
     String configUri = "";
 
@@ -150,6 +163,12 @@ public class CheckstylePreferences implements PreferenceGenerator {
     }
   }
 
+  /**
+   * Handles toggle events for the useProvidedCheckBox.
+   * Disables inputs based on the selection state.
+   * 
+   * @param event the event that caused this method to be called
+   */
   private void onUseProvidedToggle(ActionEvent event) {
     if (useProvidedCheckBox.isSelected()) {
       this.providedConfigList.setDisable(false);
@@ -162,6 +181,13 @@ public class CheckstylePreferences implements PreferenceGenerator {
     }
   }
 
+  /**
+   * Handles click events for the browseConfigPathButton.
+   * Shows a FileChooser, and sets the textInput to the files path.
+   * If a file was not chosen, it ignores setting the value.
+   * 
+   * @param event the event that caused this method to be called 
+   */
   private void onBrowseConfigPath(ActionEvent event) {
     FileChooser fileChooser = new FileChooser();
     ExtensionFilter extensionFilter = new FileChooser.ExtensionFilter("XML files (*.xml)", "*.xml");

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
@@ -1,0 +1,177 @@
+package no.ntnu.iir.bluej.checkstyle;
+
+import bluej.extensions2.BlueJ;
+import bluej.extensions2.PreferenceGenerator;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import javafx.event.ActionEvent;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import no.ntnu.iir.bluej.checkstyle.checker.CheckerService;
+
+public class CheckstylePreferences implements PreferenceGenerator {
+  private BlueJ blueJ;
+  private GridPane pane;
+  private CheckerService checkerService;
+  private CheckBox useProvidedCheckBox;
+  private ComboBox<String> providedConfigList;
+  private HashMap<String, String> providedConfigs;
+  private TextField customConfigPath;
+  private Button browseConfigPathButton;
+
+  public static final String CHECKSTYLE_USE_PROVIDED = "Checkstyle.UseProvided";
+  public static final String CHECKSTYLE_CONFIG_SELECTED = "Checkstyle.SelectedConfig";
+  public static final String CHECKSTYLE_CONFIG_PATH = "Checkstyle.CustomConfigPath";
+
+  /**
+   * Constructs a new PreferencesGenerator implemenetation.
+   * 
+   * @param blueJ the BlueJ instance to load and save preferences to
+   * @param checkerService the CheckerService instance to configure on save
+   */
+  public CheckstylePreferences(BlueJ blueJ, CheckerService checkerService) {
+    this.blueJ = blueJ;
+    this.checkerService = checkerService;
+    this.providedConfigs = new HashMap<>();
+    this.providedConfigs.put("Google", "config/google_checks.xml");
+    this.providedConfigs.put("Sun", "config/sun_checks.xml");
+    this.initPane();
+    this.loadValues();
+  }
+
+  /**
+   * Instantiates necessary UI elements and places them in the grid.
+   */
+  public void initPane() {
+    this.pane = new GridPane();
+    this.pane.setVgap(10);
+    this.pane.setHgap(5);
+
+    ColumnConstraints labelColumn = new ColumnConstraints();
+    ColumnConstraints fieldColumn = new ColumnConstraints(100, 100, Double.MAX_VALUE);
+    ColumnConstraints buttonColumn = new ColumnConstraints();
+
+    fieldColumn.setHgrow(Priority.ALWAYS);
+
+    this.pane.getColumnConstraints().addAll(labelColumn, fieldColumn, buttonColumn);
+
+    this.useProvidedCheckBox = new CheckBox();
+    this.useProvidedCheckBox.setOnAction(this::onUseProvidedToggle);
+
+    this.providedConfigList = new ComboBox<>();
+    this.providedConfigList.getItems().addAll(this.providedConfigs.keySet());
+
+    pane.add(new Label("Use provided configs"), 0, 0);
+    pane.add(useProvidedCheckBox, 1, 0);
+
+    pane.add(new Label("Select a provided config"), 0, 1);
+    pane.add(providedConfigList, 1, 1);
+
+    this.customConfigPath = new TextField();
+
+    this.browseConfigPathButton = new Button("Browse");
+    this.browseConfigPathButton.setOnAction(this::onBrowseConfigPath);
+
+    pane.add(new Label("Custom config location"), 0, 2);
+    pane.add(this.customConfigPath, 1, 2);
+    pane.add(this.browseConfigPathButton, 2, 2);
+
+  }
+
+  @Override
+  public Pane getWindow() {
+    return this.pane;
+  }
+
+  /**
+   * Loads Extension properties from BlueJs internal state.
+   */
+  @Override
+  public void loadValues() {
+    this.useProvidedCheckBox.setSelected(
+        Boolean.parseBoolean(this.blueJ.getExtensionPropertyString(CHECKSTYLE_USE_PROVIDED, "true"))
+    );
+
+    this.providedConfigList.setValue(
+        this.blueJ.getExtensionPropertyString(CHECKSTYLE_CONFIG_SELECTED, "Google")
+    );
+
+    this.customConfigPath.setText(
+        this.blueJ.getExtensionPropertyString(CHECKSTYLE_CONFIG_PATH, "")
+    );
+
+    // make UI evaluate what fields should be active on load
+    this.onUseProvidedToggle(null);
+    this.configureCheckerService();
+  }
+
+  /**
+   * Saves Extension properties to BlueJs internal state and configures the CheckerService.
+   */
+  @Override
+  public void saveValues() {
+    this.blueJ.setExtensionPropertyString(
+        CHECKSTYLE_USE_PROVIDED, String.valueOf(this.useProvidedCheckBox.isSelected())
+    );
+    this.blueJ.setExtensionPropertyString(
+        CHECKSTYLE_CONFIG_SELECTED, this.providedConfigList.getValue()
+    );
+    this.blueJ.setExtensionPropertyString(
+        CHECKSTYLE_CONFIG_PATH, this.customConfigPath.getText()
+    );
+  }
+
+  private void configureCheckerService() {
+    String configUri = "";
+
+    if (this.useProvidedCheckBox.isSelected()) {
+      String configName = this.providedConfigList.getValue();
+      String configPath = this.providedConfigs.get(configName);
+      configUri = this.getClass().getClassLoader().getResource(configPath).toString();
+    } else {
+      configUri = this.customConfigPath.getText();  
+    }
+
+    try {
+      this.checkerService.setConfiguration(configUri);
+    } catch (CheckstyleException e) {
+      // TODO: Show a dialog telling the user that the config file does not exist.
+      System.out.println("unable to open file");
+    }
+  }
+
+  private void onUseProvidedToggle(ActionEvent event) {
+    if (useProvidedCheckBox.isSelected()) {
+      this.providedConfigList.setDisable(false);
+      this.customConfigPath.setDisable(true);
+      this.browseConfigPathButton.setDisable(true);
+    } else {
+      this.providedConfigList.setDisable(true);
+      this.customConfigPath.setDisable(false);
+      this.browseConfigPathButton.setDisable(false);
+    }
+  }
+
+  private void onBrowseConfigPath(ActionEvent event) {
+    FileChooser fileChooser = new FileChooser();
+    ExtensionFilter extensionFilter = new FileChooser.ExtensionFilter("XML files (*.xml)", "*.xml");
+    fileChooser.getExtensionFilters().add(extensionFilter);
+    File fileChosen = fileChooser.showOpenDialog(this.pane.getScene().getWindow());
+
+    if (fileChosen != null) {
+      this.customConfigPath.setText(fileChosen.getPath());
+    }
+  }
+
+}

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstylePreferences.java
@@ -2,10 +2,9 @@ package no.ntnu.iir.bluej.checkstyle;
 
 import bluej.extensions2.BlueJ;
 import bluej.extensions2.PreferenceGenerator;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import java.io.File;
+import java.util.HashMap;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
@@ -6,7 +6,6 @@ import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import java.io.File;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Properties;
@@ -26,26 +25,17 @@ public class CheckerService {
     
     this.checker.setBasedir(null);
     this.checker.setModuleClassLoader(Checker.class.getClassLoader());
-    try {
-      this.setConfiguration();
-    } catch (Exception e) {
-      // TODO: Show error message/dialog to the user to let them know something is wrong
-      // Likely caused by a faulty config file used
-      e.printStackTrace();
-    }
   }
 
   /**
    * Configures Checkstyle to use given configuration.
-   * TODO: Read Configuration from BlueJ preferences.
    * 
-   * @throws IOException if an error reading the configuration file occurs.
    * @throws CheckstyleException if an error condition within Checkstyle occurs.
    */
-  public void setConfiguration() throws IOException, CheckstyleException {
+  public void setConfiguration(String configPath) throws CheckstyleException {
     Properties checkstyleProperties = new Properties();
     this.checker.configure(ConfigurationLoader.loadConfiguration(
-        this.getClass().getClassLoader().getResource("config/google_checks.xml").toString(),
+        configPath,
         new PropertiesExpander(checkstyleProperties)
     ));
   }

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
@@ -30,6 +30,8 @@ public class CheckerService {
   /**
    * Configures Checkstyle to use given configuration.
    * 
+   * @param configPath the path to the configuration file to use
+   * 
    * @throws CheckstyleException if an error condition within Checkstyle occurs.
    */
   public void setConfiguration(String configPath) throws CheckstyleException {


### PR DESCRIPTION
Issue: BLUECHECK-13

Created a class that implements the PreferenceGenerator interface from the Extensions2 API.
It is responsible for saving and loading the configuration options set by the user in the BlueJ Preferences window.

The class composes a simple UI form in JavaFX that will be displayed to the user in the Extensions tab in the Preferences window. It allows the user to select one of the two provided configuration files, or use one of their own.

The **loadValues()** method is called when BlueJ starts and when a new configuration is saved. This method has the responsibility of configuring the Checkstyle CheckerService. It also defines a set of default configuration options.