### PR TITLE
BLUECHECK-11: Use BClass instead of File for class/file reference in Violations

### DIFF
--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstyleExtension.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/CheckstyleExtension.java
@@ -3,9 +3,10 @@ package no.ntnu.iir.bluej.checkstyle;
 import bluej.extensions2.BlueJ;
 import bluej.extensions2.Extension;
 import java.util.logging.Logger;
-import no.ntnu.iir.bluej.checkstyle.core.handlers.PackageEventHandler;
 import no.ntnu.iir.bluej.checkstyle.checker.CheckerListener;
 import no.ntnu.iir.bluej.checkstyle.checker.CheckerService;
+import no.ntnu.iir.bluej.checkstyle.core.handlers.FilesChangeHandler;
+import no.ntnu.iir.bluej.checkstyle.core.handlers.PackageEventHandler;
 import no.ntnu.iir.bluej.checkstyle.core.violations.ViolationManager;
 
 public class CheckstyleExtension extends Extension {
@@ -13,13 +14,26 @@ public class CheckstyleExtension extends Extension {
   
   @Override
   public void startup(BlueJ blueJ) {
-    LOGGER.info("Starting checkstyle4bluej");
-
-    ViolationManager violationManager = new ViolationManager();
-    blueJ.addPackageListener(new PackageEventHandler("checkstyle4bluej", violationManager));
+    LOGGER.info("Starting " + this.getName());
+    
     CheckerService checkerService = new CheckerService();
+    ViolationManager violationManager = new ViolationManager();
+    PackageEventHandler packageEventHandler = new PackageEventHandler(
+        this.getName(),
+        violationManager
+    );
+
     CheckerListener checkerListener = new CheckerListener(violationManager);
+
     checkerService.addListener(checkerListener);
+    
+    FilesChangeHandler filesChangeHandler = new FilesChangeHandler(
+        violationManager, 
+        checkerService
+    );
+
+    blueJ.addClassListener(filesChangeHandler);
+    blueJ.addPackageListener(packageEventHandler);
   }
 
   @Override

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/checker/CheckerService.java
@@ -10,12 +10,13 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Properties;
+import no.ntnu.iir.bluej.checkstyle.core.checker.ICheckerService;
 
 /**
  * Represents a Checker service.
  * Responsible for handling requests to check files using a Checkstyle checker.
  */
-public class CheckerService {
+public class CheckerService implements ICheckerService {
   private Checker checker;
 
   /**

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/checker/ICheckerService.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/checker/ICheckerService.java
@@ -13,14 +13,18 @@ public interface ICheckerService {
    * 
    * @param fileToCheck the File to check.
    * @param charset the Charset of the File to check.
+   * 
+   * @throws Exception if an error occurs while processing the file
    */
-  void checkFile(File fileToCheck, String charset);
+  void checkFile(File fileToCheck, String charset) throws Exception;
 
-  /**
+  /**-
    * Checks a List of files.
    * 
    * @param filesToCheck a List of Files to check.
    * @param charset the Charset of the Files to check
+   * 
+   * @throws Exception if an error occurs while processing files
    */
-  void checkFiles(List<File> filesToCheck, String charset);
+  void checkFiles(List<File> filesToCheck, String charset) throws Exception;
 }

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/editor/EditorNotifier.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/editor/EditorNotifier.java
@@ -25,22 +25,26 @@ public class EditorNotifier {
    * Fetches the JavaEditor proxy or opens a new one.
    * Sets the JavaEditor to be visible, and then sets the selection.
    * 
-   * @param blueClass the BClass to fetch the JavaEditor proxy object from
-   * @param textLocation the TextLocation of where to highlight
+   * @param violation the source violation to highlight in the editor
    * 
    * @throws ProjectNotOpenException if the BCLass' project was not open
    * @throws PackageNotFoundException if the BClass' package was not found
    */
   public static void highlightLine(
-      BClass blueClass, 
-      TextLocation textLocation
+      Violation violation
   ) throws ProjectNotOpenException, PackageNotFoundException {
+    BClass blueClass = violation.getBClass();
+    TextLocation textLocation = violation.getLocation();
     JavaEditor fileEditor = blueClass.getJavaEditor();
+
+    int lineNumber = textLocation.getLine() - 1;
     int lineLength = fileEditor.getLineLength(textLocation.getLine() - 1);
+    int startColumn = (textLocation.getColumn() > 0) ? textLocation.getColumn() - 1 : 1;
+
     fileEditor.setVisible(true);
     fileEditor.setSelection(
-        textLocation,
-        new TextLocation(textLocation.getLine(), lineLength)
+        new TextLocation(lineNumber, startColumn),
+        new TextLocation(lineNumber, lineLength)
     );
   }
 
@@ -49,17 +53,17 @@ public class EditorNotifier {
    * Uses the EditorBridge to get Editor from JavaEditor proxy object.
    * Utilizes the Editor object to show a Diagnostic message to the user.
    * 
-   * @param blueClass the BClass to fetch the JavaEditor proxy object from
    * @param violation the Violation to show diagnostic message about
    */
   public static void showDiagnostic(
-      BClass blueClass, 
       Violation violation
   ) throws ProjectNotOpenException, PackageNotFoundException {
+    BClass blueClass = violation.getBClass();
     JavaEditor javaEditor = blueClass.getJavaEditor();
-    javaEditor.setVisible(true);
     Editor editor = EditorBridge.getJavaEditor(javaEditor);
     TextLocation textLocation = violation.getLocation();
+    int startLine = (textLocation.getLine() > 0) ? textLocation.getLine() : 1;      
+    int startColumn = (textLocation.getColumn() > 0) ? textLocation.getColumn() : 1;
     int lineLength = javaEditor.getLineLength(textLocation.getLine() - 1);
 
     // TODO: Check effect of identifier
@@ -67,9 +71,9 @@ public class EditorNotifier {
         1,                                      // type
         violation.getSummary(),                 // message
         violation.getFile().getName(),          // fileName
-        Long.valueOf(textLocation.getLine()),   // startLine
-        Long.valueOf(textLocation.getColumn()), // startColumn
-        Long.valueOf(textLocation.getLine()),   // endLine
+        Long.valueOf(startLine),                // startLine
+        Long.valueOf(startColumn),              // startColumn
+        Long.valueOf(startLine),                // endLine
         Long.valueOf(lineLength),               // endColumn
         DiagnosticOrigin.UNKNOWN,               // origin
         1                                       // identifier

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/handlers/PackageEventHandler.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/handlers/PackageEventHandler.java
@@ -19,8 +19,8 @@ public class PackageEventHandler implements PackageListener {
   /**
    * Instantiates a new handler for Package events.
    * 
-   * @param windowTitlePrefix the title prefix of audit windows spawned.
-   * @param violationManager the ViolationManager for windows to subscribe to.
+   * @param windowTitlePrefix the title prefix of audit windows spawned
+   * @param violationManager the ViolationManager for windows to subscribe to
    */
   public PackageEventHandler(String windowTitlePrefix, ViolationManager violationManager) {
     this.projectWindowMap = new HashMap<>();
@@ -36,6 +36,7 @@ public class PackageEventHandler implements PackageListener {
   public void packageClosing(PackageEvent packageEvent) {
     try {
       String packagePath = packageEvent.getPackage().getDir().getPath();
+      this.violationManager.removeBluePackage(packageEvent.getPackage());
       AuditWindow projectWindow = this.projectWindowMap.get(packagePath);
       if (projectWindow != null && projectWindow.isShowing()) {
         this.violationManager.removeListener(projectWindow);
@@ -60,8 +61,11 @@ public class PackageEventHandler implements PackageListener {
           packageEvent.getPackage(), 
           packagePath
       );
+      
+      this.violationManager.addBluePackage(packageEvent.getPackage());
       this.violationManager.addListener(projectWindow);
       this.projectWindowMap.put(packagePath, projectWindow);
+
       projectWindow.show();
 
       // TODO: Call a check on all files in the opened project

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/ui/ViolationCell.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/ui/ViolationCell.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.web.WebView;
+import no.ntnu.iir.bluej.checkstyle.core.editor.EditorNotifier;
 import no.ntnu.iir.bluej.checkstyle.core.violations.RuleDefinition;
 import no.ntnu.iir.bluej.checkstyle.core.violations.Violation;
 
@@ -70,21 +71,28 @@ public class ViolationCell extends ListCell<Violation> {
    * @param mouseEvent the MouseEvent emitted when a user clicks the cell.
    */
   private void handleMouseClick(MouseEvent mouseEvent) {
-    if (mouseEvent.getClickCount() == 2) {
-      // show the violation in the editor
-    } else {
-      // render rule description if any
-      RuleDefinition definition = violation.getRuleDefinition();
-
-      if (definition == null) {
-        this.ruleWebView.getEngine().loadContent(
-            "The selected violation does not have a rule description..."
-        );
+    // only handle clicks where a cell has content.
+    if (violation != null) {      
+      if (mouseEvent.getClickCount() == 2) {
+        try {
+          EditorNotifier.highlightLine(violation);
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
       } else {
-        ruleWebView.getEngine().loadContent(
-            definition.getDescription(),
-            "text/html"
-        );
+        // render rule description if any
+        RuleDefinition definition = violation.getRuleDefinition();
+  
+        if (definition == null) {
+          this.ruleWebView.getEngine().loadContent(
+              "The selected violation does not have a rule description..."
+          );
+        } else {
+          ruleWebView.getEngine().loadContent(
+              definition.getDescription(),
+              "text/html"
+          );
+        }
       }
     }
   }

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/Violation.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/Violation.java
@@ -1,5 +1,8 @@
 package no.ntnu.iir.bluej.checkstyle.core.violations;
 
+import bluej.extensions2.BClass;
+import bluej.extensions2.PackageNotFoundException;
+import bluej.extensions2.ProjectNotOpenException;
 import bluej.extensions2.editor.TextLocation;
 import java.io.File;
 
@@ -11,7 +14,7 @@ import java.io.File;
  */
 public class Violation {
   private String summary;
-  private File file;
+  private BClass blueClass;
   private TextLocation location;
   private RuleDefinition ruleDefinition;
 
@@ -19,12 +22,12 @@ public class Violation {
    * Constructs a new Violation without a RuleDefinition.
    * 
    * @param summary a String containing a brief explanation of the violation
-   * @param file the File where the violation was found
+   * @param blueClass the BlueJ Class file where the violation was found
    * @param location the TextLocation where the violation was found in the file
    */
-  public Violation(String summary, File file, TextLocation location) {
+  public Violation(String summary, BClass blueClass, TextLocation location) {
     this.summary = summary;
-    this.file = file;
+    this.blueClass = blueClass;
     this.location = location;
   }
 
@@ -32,18 +35,18 @@ public class Violation {
    * Constructs a new Violation with a RuleDefinition.
    * 
    * @param summary a String containing a brief explanation of the violation
-   * @param file the File where the violation was found
+   * @param blueClass the BlueJ Class file where the violation was found
    * @param location the TextLocation where the violation was found in the file
    * @param ruleDefinition a RuleDefinition containing a description of the violated rule
    */
   public Violation(
       String summary, 
-      File file, 
+      BClass blueClass, 
       TextLocation location, 
       RuleDefinition ruleDefinition
   ) {
     this.summary = summary;
-    this.file = file;
+    this.blueClass = blueClass;
     this.location = location;
     this.ruleDefinition = ruleDefinition;
   }
@@ -58,18 +61,27 @@ public class Violation {
   }
 
   /**
+   * Returns the BlueJ Class instance where the violation was found. 
+   * 
+   * @return the BlueJ Class instance where the violation was found
+   */
+  public BClass getBClass() {
+    return this.blueClass;
+  }
+
+  /**
    * Returns the file where the violation was found.
    * 
-   * @return the File where the violation was found.
+   * @return the File where the violation was found
    */
-  public File getFile() {
-    return file;
+  public File getFile() throws ProjectNotOpenException, PackageNotFoundException {
+    return this.blueClass.getJavaFile();
   }
 
   /**
    * Returns the TextLocation of where the violation was found in the file.
    * 
-   * @return the TextLocation where the violation was found in the file.
+   * @return the TextLocation where the violation was found in the file
    */
   public TextLocation getLocation() {
     return location;
@@ -79,7 +91,7 @@ public class Violation {
   /**
    * Returns the RuleDefinition of the violated rule.
    * 
-   * @return the RuleDefinition of the violated rule.
+   * @return the RuleDefinition of the violated rule
    */
   public RuleDefinition getRuleDefinition() {
     return ruleDefinition;

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/ViolationManager.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/ViolationManager.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 /**
  * Represents a Violation manager.
- * Responsible for managing violations and notifying listeners
- * when violations change.
+ * Responsible for managing violations and notifying listeners when violations change. 
+ * Also handles mapping between file paths and BlueJ Class instances.
  */
 public class ViolationManager {
   private List<ViolationListener> listeners;
@@ -132,6 +132,13 @@ public class ViolationManager {
     }
   }
 
+  /**
+   * Gets a BlueJ Class instance from a files path.
+   * 
+   * @param filePath the path of the file to find a BlueJ Class from
+   * 
+   * @return the found BlueJ Class instance or null
+   */
   public BClass getBlueClass(String filePath) {
     return this.blueClassMap.get(filePath);
   }

--- a/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/ViolationManager.java
+++ b/src/main/java/no/ntnu/iir/bluej/checkstyle/core/violations/ViolationManager.java
@@ -1,5 +1,9 @@
 package no.ntnu.iir.bluej.checkstyle.core.violations;
 
+import bluej.extensions2.BClass;
+import bluej.extensions2.BPackage;
+import bluej.extensions2.PackageNotFoundException;
+import bluej.extensions2.ProjectNotOpenException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,6 +16,8 @@ import java.util.List;
 public class ViolationManager {
   private List<ViolationListener> listeners;
   private HashMap<String, List<Violation>> violations;
+  private List<BPackage> bluePackages;
+  private HashMap<String, BClass> blueClassMap;
 
   /**
    * Constructs a new Violation manager.
@@ -19,6 +25,8 @@ public class ViolationManager {
   public ViolationManager() {
     this.listeners = new ArrayList<>();
     this.violations = new HashMap<>();
+    this.bluePackages = new ArrayList<>();
+    this.blueClassMap = new HashMap<>();
   }
 
   /**
@@ -88,5 +96,43 @@ public class ViolationManager {
    */
   private void notifyListeners() {
     this.listeners.forEach(listener -> listener.onViolationsChanged(this.violations));
+  }
+
+  /**
+   * Adds a BlueJ package to the list of packages to sync file names and BlueJ classes from. 
+   * 
+   * @param bluePackage the BlueJ Package to add to the list of packages
+   */
+  public void addBluePackage(BPackage bluePackage) {
+    this.bluePackages.add(bluePackage);
+  }
+
+  /**
+   * Removes a BlueJ Package from the list of packages to sync files names and BlueJ classes from.
+   * 
+   * @param bluePackage the BlueJ Package to remove from the list of packages
+   */
+  public void removeBluePackage(BPackage bluePackage) {
+    this.bluePackages.remove(bluePackage);
+  }
+
+  /**
+   * Synchronizes the blueClassMap with the BClasses in the current package.
+   * 
+   * @throws ProjectNotOpenException if the BlueJ project was not opened
+   * @throws PackageNotFoundException if the Package was not found
+   */
+  public void syncBlueClassMap() throws ProjectNotOpenException, PackageNotFoundException {
+    for (BPackage bluePackage : this.bluePackages) {
+      BClass[] blueClasses = bluePackage.getClasses();
+      for (BClass blueClass : blueClasses) {
+        String filePath = blueClass.getJavaFile().getPath();
+        this.blueClassMap.put(filePath, blueClass);
+      }
+    }
+  }
+
+  public BClass getBlueClass(String filePath) {
+    return this.blueClassMap.get(filePath);
   }
 }


### PR DESCRIPTION
Issue: BLUECHECK-11

Changed from using a File reference to using a BClass reference. BClass contains a reference to the File, along with more functionality. 

Also added mapping of filePaths to BClasses that will allow you to easily get the BClass instance for a file based on its path. 
It synchronizes the map on every audit start.